### PR TITLE
[FEAT] 특정 유저의 총 달린거리를 계산하는 로직 구현 및 유저 토큰 방식 변경 및 errorResponse에러 응답 구조 반영

### DIFF
--- a/src/main/java/com/umc/yourun/config/exception/ErrorResponse.java
+++ b/src/main/java/com/umc/yourun/config/exception/ErrorResponse.java
@@ -1,4 +1,4 @@
 package com.umc.yourun.config.exception;
 
-public record ErrorResponse(int code, String message) {
+public record ErrorResponse(int status,String code, String message) {
 }

--- a/src/main/java/com/umc/yourun/controller/RunningRestController.java
+++ b/src/main/java/com/umc/yourun/controller/RunningRestController.java
@@ -7,10 +7,12 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.umc.yourun.apiPayload.ApiResponse;
+import com.umc.yourun.config.exception.ErrorResponse;
 import com.umc.yourun.converter.RunningDataConverter;
 import com.umc.yourun.domain.RunningData;
 import com.umc.yourun.domain.enums.RunningDataStatus;
@@ -18,6 +20,10 @@ import com.umc.yourun.dto.runningdata.RunningDataRequestDTO;
 import com.umc.yourun.dto.runningdata.RunningDataResponseDTO;
 import com.umc.yourun.service.RunningService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -32,28 +38,55 @@ public class RunningRestController {
 
 	private final RunningService runningService;
 
+	@Operation(summary = "RUNNING_DATA_API_01 : 크루 챌린지 생성", description = "새로운 러닝 데이터를 생성합니다.")
+	@ApiResponses(value = {
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "러닝데이터 생성 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
 	@PostMapping
-	public ApiResponse<RunningDataResponseDTO.createRunningData> createRunningData(@RequestBody @Valid RunningDataRequestDTO.CreateRunningDataReq request) {
-		RunningData runningData = runningService.createRunningData(request);
+	public ApiResponse<RunningDataResponseDTO.createRunningData> createRunningData(@RequestHeader(value = "Authorization") String accessToken,
+																					@RequestBody @Valid RunningDataRequestDTO.CreateRunningDataReq request) {
+		RunningData runningData = runningService.createRunningData(accessToken,request);
 		return ApiResponse.success("러닝 결과 정보 생성 성공", RunningDataConverter.toCreateRunningDataRes(runningData));
 	}
 
+	@Operation(summary = "RUNNING_DATA_API_01 : 특정 년/월의 모든 러닝데이터 조회(캘린더에서 사용)", description = "특정한 년/월의 모든 러닝 데이터를 조회합니다.")
+	@ApiResponses(value = {
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "러닝데이터 조회 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
 	@GetMapping("/{years}/{months}")
-	public ApiResponse<List<RunningDataResponseDTO.RunningDataInfo>> getRunningDataMonthly(@PathVariable @Valid @Min(value = 2025,message = "2025년 이후부터 조회 가능합니다.") int years,
-																											@PathVariable @Valid @Min(value = 1,message = "1월부터 12월사이의 값만 조회가능합니다.") @Max(value = 12,message = "1월부터 12월사이의 값만 조회가능합니다.") int months) {
+	public ApiResponse<List<RunningDataResponseDTO.RunningDataInfo>> getRunningDataMonthly(@RequestHeader(value = "Authorization") String accessToken,
+																							@PathVariable @Valid @Min(value = 2025,message = "2025년 이후부터 조회 가능합니다.") int years,
+																							@PathVariable @Valid @Min(value = 1,message = "1월부터 12월사이의 값만 조회가능합니다.") @Max(value = 12,message = "1월부터 12월사이의 값만 조회가능합니다.") int months) {
 
-		List<RunningData> runningDataList = runningService.getRunningDataMonthly(years, months);
+		List<RunningData> runningDataList = runningService.getRunningDataMonthly(accessToken,years, months);
 		return ApiResponse.success("특정 월/일 러닝 데이터 조회 성공", RunningDataConverter.toRunningDataRes(runningDataList));
 	}
 
+	@Operation(summary = "RUNNING_DATA_API_03 : 러닝 데이터 조회", description = "특정 id의 러닝 데이터를 조회합니다.")
+	@ApiResponses(value = {
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "러닝데이터 조회 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
 	@GetMapping("/{id}")
-	public ApiResponse<RunningDataResponseDTO.RunningDataInfo> getRunningData(@PathVariable Long id) {
+	public ApiResponse<RunningDataResponseDTO.RunningDataInfo> getRunningData(@RequestHeader(value = "Authorization") String accessToken,
+																				@PathVariable Long id) {
 		RunningData runningData = runningService.getRunningDataById(id);
 		return ApiResponse.success("러닝 데이터 조회 성공", RunningDataConverter.toRunningDataRes(runningData));
 	}
 
+	@Operation(summary = "RUNNING_DATA_API_04 : 러닝 데이터 삭제", description = "특정 id의 러닝 데이터를 삭제합니다.")
+	@ApiResponses(value = {
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "러닝데이터 삭제 성공"),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
 	@PatchMapping("/{id}")
-	public ApiResponse<RunningDataResponseDTO.RunningDataInfo> deleteRunningData(@PathVariable Long id) {
+	public ApiResponse<RunningDataResponseDTO.RunningDataInfo> deleteRunningData(@RequestHeader(value = "Authorization") String accessToken,
+																					@PathVariable Long id) {
 		RunningData runningData = runningService.updateRunningData(id, RunningDataStatus.DELETED);
 		return ApiResponse.success("러닝 데이터 삭제 성공", RunningDataConverter.toRunningDataRes(runningData));
 	}

--- a/src/main/java/com/umc/yourun/repository/RunningDataRepository.java
+++ b/src/main/java/com/umc/yourun/repository/RunningDataRepository.java
@@ -22,12 +22,20 @@ public interface RunningDataRepository extends JpaRepository<RunningData, Long> 
 
 	Optional<RunningData> findByIdAndStatus(Long id, RunningDataStatus status);
 
+	//특정 사용자의 총 러닝 거리 조회
+	@Query("SELECT COALESCE(SUM(r.totalDistance), 0) " +
+		"FROM RunningData r " +
+		"WHERE r.user.id = :userId " +
+		"AND r.status = 'ACTIVE'")
+	int sumDistanceByUserId(@Param("userId") Long userId);
+
     // 특정 사용자의 특정 기간 동안의 총 러닝 거리 조회 (크루원별 달린 거리 포함된 진행도 확인용)
     @Query("SELECT COALESCE(SUM(r.totalDistance), 0) " +
             "FROM RunningData r " +
             "WHERE r.user.id = :userId " +
             "AND r.startTime >= :startDate " +
-            "AND r.endTime <= :endDate")
+            "AND r.endTime <= :endDate " +
+			"AND r.status = 'ACTIVE'")
     int sumDistanceByUserIdAndPeriod(
             @Param("userId") Long userId,
             @Param("startDate") LocalDateTime startDate,

--- a/src/main/java/com/umc/yourun/service/RunningService.java
+++ b/src/main/java/com/umc/yourun/service/RunningService.java
@@ -9,9 +9,9 @@ import com.umc.yourun.dto.runningdata.RunningDataRequestDTO;
 import jakarta.validation.Valid;
 
 public interface RunningService {
-	RunningData createRunningData(RunningDataRequestDTO.@Valid CreateRunningDataReq request);
+	RunningData createRunningData(String accessToken,RunningDataRequestDTO.@Valid CreateRunningDataReq request);
 
-	List<RunningData> getRunningDataMonthly(int years, int months);
+	List<RunningData> getRunningDataMonthly(String accessToken,int years, int months);
 
 	RunningData getRunningDataById(Long id);
 

--- a/src/main/java/com/umc/yourun/service/RunningServiceImpl.java
+++ b/src/main/java/com/umc/yourun/service/RunningServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.yourun.config.JwtTokenProvider;
 import com.umc.yourun.config.exception.ErrorCode;
 import com.umc.yourun.config.exception.GeneralException;
 import com.umc.yourun.config.exception.custom.RunningException;
@@ -29,23 +30,23 @@ public class RunningServiceImpl implements RunningService{
 	private final RunningDataRepository runningDataRepository;
 	private final UserRepository userRepository;
 	private final UserService UserService;
+	private final JwtTokenProvider jwtTokenProvider;
 
 	@Override
 	@Transactional
-	public RunningData createRunningData(RunningDataRequestDTO.@Valid CreateRunningDataReq request) {
+	public RunningData createRunningData(String accessToken,RunningDataRequestDTO.@Valid CreateRunningDataReq request) {
+		User user = jwtTokenProvider.getUserByToken(accessToken);
 		Integer totalTime=calculateTotalTime(request.startTime(),request.endTime());
 		if(totalTime<0) {
 			throw new RunningException(ErrorCode.INVALID_END_TIME);
 		}
-		User user=userRepository.findById(request.userId()).orElseThrow(()->new RunningException(ErrorCode.USER_NOT_FOUND));
 		RunningData runningData= RunningDataConverter.toRunningData(request,totalTime,user);
 		return runningDataRepository.save(runningData);
 	}
 
 	@Override
-	public List<RunningData> getRunningDataMonthly(int years, int months) {
-		//TODO: 토큰에서 가져오기
-		User user=userRepository.findById(1L).orElseThrow(()->new RunningException(ErrorCode.USER_NOT_FOUND));
+	public List<RunningData> getRunningDataMonthly(String accessToken,int years, int months) {
+		User user = jwtTokenProvider.getUserByToken(accessToken);
 		LocalDateTime startDateTime = LocalDateTime.of(years, months, 1, 0, 0, 0);
 		LocalDateTime endDateTime = startDateTime.plusMonths(1);
 		return runningDataRepository.findByStatusAndStartTimeBetweenAndUser(RunningDataStatus.ACTIVE,startDateTime,endDateTime,user);


### PR DESCRIPTION
## 🚀 관련 이슈
- close #57   //

## 🔑 주요 변경사항
- 특정 유저의 총 달린거리를 계산하는 repository 함수 구현 @Choi-seokun 메이트 조회시 참고 바람
- 유저 토큰 방식 변경
- #43  에서 변경했던 응답구조를 swagger 의 errorResponse content 설정에 제대로 반영하기 위한 변경

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [x] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
