### PR TITLE
[FEAT] 러닝 후 크루 챌린지 결과(진행도) 조회 API 완료 

### DIFF
--- a/src/main/java/com/umc/yourun/config/exception/ErrorCode.java
+++ b/src/main/java/com/umc/yourun/config/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     CREW_CHALLENGE_FULL(400, "C015", "크루 인원이 모두 찼습니다."),
     DUPLICATE_CREW_NAME(400, "C016", "이미 사용 중인 크루명입니다."),
     NO_CREW_CHALLENGE_FOUND(400, "C017", "사용자는 크루에 참여하고 있지 않습니다."),
+    CREW_CHALLENGE_COMPLETED(500, "C018", "두 크루 챌린지가 모두 COMPLETED 상태여야 결과를 확인할 수 있습니다."),
 
     //Running 관련 에러
     INVALID_END_TIME(400, "R001", "종료 시간은 시작 시간 이후여야 합니다."),

--- a/src/main/java/com/umc/yourun/controller/CrewChallengeRestController.java
+++ b/src/main/java/com/umc/yourun/controller/CrewChallengeRestController.java
@@ -133,4 +133,19 @@ public class CrewChallengeRestController {
         ChallengeResponse.CrewChallengeContributionRes response = challengeService.getCrewChallengeContribution(accessToken);
         return ApiResponse.success("크루 챌린지 순위 결과입니다.", response);
     }
+
+    @Operation(summary = "CREW_CHALLENGE_API_08 : 러닝 후 크루 챌린지 결과 조회", description = "러닝 후 크루 챌린지의 결과를 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "참여중인 크루 챌린지가 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/running-result")
+    public ApiResponse<ChallengeResponse.CrewChallengeRunningResult> getCrewChallengeRunningResult(
+            @RequestHeader(value = "Authorization") String accessToken) {
+        ChallengeResponse.CrewChallengeRunningResult response = challengeService.getCrewChallengeRunningResult(accessToken);
+        return ApiResponse.success("러닝 후 크루 챌린지 결과입니다.", response);
+    }
 }

--- a/src/main/java/com/umc/yourun/dto/challenge/ChallengeResponse.java
+++ b/src/main/java/com/umc/yourun/dto/challenge/ChallengeResponse.java
@@ -255,10 +255,7 @@ public class ChallengeResponse {
             double matchedCrewDistance,
 
             @Schema(description = "현재시간", example = "2024/01/23 14:30")
-            String now,
-
-            @Schema(description = "유저 크루가 이기고 있는지", example = "true")
-            boolean win
+            String now
     ) {}
 
     @Schema(description = "CHALLENGE_RES_07 - 1 : 크루원 정보")

--- a/src/main/java/com/umc/yourun/dto/challenge/ChallengeResponse.java
+++ b/src/main/java/com/umc/yourun/dto/challenge/ChallengeResponse.java
@@ -410,7 +410,7 @@ public class ChallengeResponse {
 
     ) {}
 
-    @Schema(title = "CHALLENGE_RES_13 : 러닝 후 크루 챌린지 순위 결과 조회 응답 DTO")
+    @Schema(title = "CHALLENGE_RES_13 : 크루 챌린지 순위 결과 조회 응답 DTO")
     public record CrewChallengeContributionRes (
 
             @Schema(description = "챌린지 기간", example = "3")
@@ -445,6 +445,35 @@ public class ChallengeResponse {
 
             @Schema(description = "달린 거리 별 순위", example = "1")
             int rank
+    ) {}
+
+    @Schema(description = "CHALLENGE_RES_08 : 러닝 후 크루 챌린지 결과 응답 DTO")
+    public record CrewChallengeRunningResult(
+
+            @Schema(description = "설정된 기간", example = "3")
+            int challengePeriod,
+
+            @Schema(description = "내 크루명", example = "거진홍길동")
+            String myCrewName,
+
+            @Schema(description = "유저가 뛰기 전 크루 총 거리", example = "12.8")
+            double beforeDistance,
+
+            @Schema(description = "유저가 방금 뛴 거리", example = "5.2")
+            double userDistance,
+
+            @Schema(description = "유저가 뛰어서 추가된 크루 총 거리", example = "18")
+            double afterDistance,
+
+            @Schema(description = "매칭된 크루 명", example = "거진이봉주")
+            String matchedCrewName,
+
+            @Schema(description = "매칭된 크루 생성자 성향", example = "스프린터")
+            Tendency matchedCrewCreator,
+
+            @Schema(description = "매칭된 크루 총 거리", example = "10")
+            double matchedCrewDistance
+
     ) {}
 
 }

--- a/src/main/java/com/umc/yourun/repository/CrewChallengeRepository.java
+++ b/src/main/java/com/umc/yourun/repository/CrewChallengeRepository.java
@@ -61,7 +61,7 @@ public interface CrewChallengeRepository extends JpaRepository<CrewChallenge, Lo
     // 마감 시간 지난 챌린지 조회
     List<CrewChallenge> findByChallengeStatusAndEndDateBefore(
             ChallengeStatus status,
-            LocalDate date
+            LocalDateTime date
     );
 
 }

--- a/src/main/java/com/umc/yourun/repository/RunningDataRepository.java
+++ b/src/main/java/com/umc/yourun/repository/RunningDataRepository.java
@@ -41,4 +41,7 @@ public interface RunningDataRepository extends JpaRepository<RunningData, Long> 
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate
     );
+
+	// 특정 사용자의 가장 최근 러닝 데이터 (러닝 후 결과 조회 확인용)
+	Optional<RunningData> findTopByUserIdAndStatusOrderByCreatedAtDesc(Long userId, RunningDataStatus status);
 }

--- a/src/main/java/com/umc/yourun/repository/SoloChallengeRepository.java
+++ b/src/main/java/com/umc/yourun/repository/SoloChallengeRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -28,7 +29,7 @@ public interface SoloChallengeRepository extends JpaRepository<SoloChallenge, Lo
     // 마감 시간 지난 챌린지 조회
     List<SoloChallenge> findByChallengeStatusAndEndDateBefore(
             ChallengeStatus status,
-            LocalDate date
+            LocalDateTime date
     );
 
 }

--- a/src/main/java/com/umc/yourun/service/ChallengeMatchService.java
+++ b/src/main/java/com/umc/yourun/service/ChallengeMatchService.java
@@ -122,6 +122,7 @@ public class ChallengeMatchService {
         }
 
         // 2. 크루 챌린지 종료 처리
+        // FIXME : 크루 챌린지의 경우 매칭된 크루도 마감시간이 되어야지 COMPLETED 처리
         List<CrewChallenge> expiredCrewChallenges = crewChallengeRepository
                 .findByChallengeStatusAndEndDateBefore(
                         ChallengeStatus.IN_PROGRESS,

--- a/src/main/java/com/umc/yourun/service/ChallengeMatchService.java
+++ b/src/main/java/com/umc/yourun/service/ChallengeMatchService.java
@@ -1,5 +1,7 @@
 package com.umc.yourun.service;
 
+import com.umc.yourun.config.exception.ErrorCode;
+import com.umc.yourun.config.exception.custom.ChallengeException;
 import com.umc.yourun.domain.CrewChallenge;
 import com.umc.yourun.domain.SoloChallenge;
 import com.umc.yourun.domain.enums.ChallengeStatus;
@@ -9,6 +11,7 @@ import com.umc.yourun.repository.UserCrewChallengeRepository;
 import com.umc.yourun.repository.UserSoloChallengeRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -121,8 +124,7 @@ public class ChallengeMatchService {
             soloChallengeRepository.save(challenge);
         }
 
-        // 2. 크루 챌린지 종료 처리
-        // FIXME : 크루 챌린지의 경우 매칭된 크루도 마감시간이 되어야지 COMPLETED 처리
+        // 2. 크루 챌린지 종료 처리 (수정된 로직 : 두 크루 챌린지 모두 마감시간이 되어야 COMPLETED 상태가 되도록)
         List<CrewChallenge> expiredCrewChallenges = crewChallengeRepository
                 .findByChallengeStatusAndEndDateBefore(
                         ChallengeStatus.IN_PROGRESS,
@@ -130,8 +132,23 @@ public class ChallengeMatchService {
                 );
 
         for (CrewChallenge challenge : expiredCrewChallenges) {
-            challenge.updateStatus(ChallengeStatus.COMPLETED);
-            crewChallengeRepository.save(challenge);
+            // 매칭된 크루 챌린지 조회
+            CrewChallenge matchedChallenge = crewChallengeRepository
+                    .findById(challenge.getMatchedCrewChallengeId())
+                    .orElseThrow(() -> new ChallengeException(ErrorCode.CHALLENGE_NOT_FOUND));
+
+            // 둘 중 더 늦은 종료 시간 확인
+            LocalDateTime laterEndDate = challenge.getEndDate().isAfter(matchedChallenge.getEndDate())
+                    ? challenge.getEndDate()
+                    : matchedChallenge.getEndDate();
+
+            // 현재 시간이 더 늦은 종료 시간을 지났을 경우에만 두 챌린지 모두 COMPLETED로 변경
+            if (now.isAfter(laterEndDate)) {
+                challenge.updateStatus(ChallengeStatus.COMPLETED);
+                matchedChallenge.updateStatus(ChallengeStatus.COMPLETED);
+                crewChallengeRepository.save(challenge);
+                crewChallengeRepository.save(matchedChallenge);
+            }
         }
     }
 

--- a/src/main/java/com/umc/yourun/service/ChallengeMatchService.java
+++ b/src/main/java/com/umc/yourun/service/ChallengeMatchService.java
@@ -13,6 +13,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Random;
 
@@ -105,13 +106,13 @@ public class ChallengeMatchService {
     // 마감시간이 된 챌린지들 상태 COMPLETED 로 변경
     @Scheduled(fixedRate = 60000) // 1분 마다 실행
     public void completeExpiredChallenges() {
-        LocalDate today = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
 
         // 1. 솔로 챌린지 종료 처리
         List<SoloChallenge> expiredSoloChallenges = soloChallengeRepository
                 .findByChallengeStatusAndEndDateBefore(
                         ChallengeStatus.IN_PROGRESS,
-                        today
+                        now
                 );
 
         for (SoloChallenge challenge : expiredSoloChallenges) {
@@ -123,7 +124,7 @@ public class ChallengeMatchService {
         List<CrewChallenge> expiredCrewChallenges = crewChallengeRepository
                 .findByChallengeStatusAndEndDateBefore(
                         ChallengeStatus.IN_PROGRESS,
-                        today
+                        now
                 );
 
         for (CrewChallenge challenge : expiredCrewChallenges) {

--- a/src/main/java/com/umc/yourun/service/ChallengeService.java
+++ b/src/main/java/com/umc/yourun/service/ChallengeService.java
@@ -509,11 +509,9 @@ public class ChallengeService {
                 .mapToDouble(memberId -> calculateTotalDistance(myCrew.getMatchedCrewChallengeId(), memberId))
                 .sum();
 
-        boolean win = myCrewDistance >= matchedCrewDistance;
-
         return new ChallengeResponse.CrewChallengeDetailProgressRes(challengePeriod, crewName, myCrew.getSlogan(), myCrewMembers,
                 myCrewDistance, matchedCrewName, matchedCrew.getSlogan(),
-                matchedCrewCreator.get().getUser().getTendency(), matchedCrewDistance, formatDateTime(LocalDateTime.now()), win);
+                matchedCrewCreator.get().getUser().getTendency(), matchedCrewDistance, formatDateTime(LocalDateTime.now()));
 
     }
 

--- a/src/main/java/com/umc/yourun/service/ChallengeService.java
+++ b/src/main/java/com/umc/yourun/service/ChallengeService.java
@@ -6,10 +6,12 @@ import com.umc.yourun.config.exception.GeneralException;
 import com.umc.yourun.config.exception.custom.ChallengeException;
 import com.umc.yourun.converter.ChallengeConverter;
 import com.umc.yourun.domain.CrewChallenge;
+import com.umc.yourun.domain.RunningData;
 import com.umc.yourun.domain.SoloChallenge;
 import com.umc.yourun.domain.User;
 import com.umc.yourun.domain.enums.ChallengePeriod;
 import com.umc.yourun.domain.enums.ChallengeStatus;
+import com.umc.yourun.domain.enums.RunningDataStatus;
 import com.umc.yourun.domain.enums.Tendency;
 import com.umc.yourun.domain.mapping.UserCrewChallenge;
 import com.umc.yourun.domain.mapping.UserSoloChallenge;
@@ -486,7 +488,7 @@ public class ChallengeService {
         String crewName = myCrew.getCrewName();
 
         // 2. 유저가 속한 크루의 크루원들 정보
-        List<ChallengeResponse.CrewMemberInfo> myCrewMembers = sortCrewMembersWithUser(user.getId(), challengeId);
+        List<ChallengeResponse.CrewMemberInfo> myCrewMembers = getCrewMemberInfo(user.getId(), challengeId);
 
         // 3. 매칭된 크루 정보 조회
         CrewChallenge matchedCrew = crewChallengeRepository.findById(myCrew.getMatchedCrewChallengeId())
@@ -628,7 +630,7 @@ public class ChallengeService {
 
     }
 
-    // 크루 챌린지 기여도 결과 화면
+    // 크루 챌린지 순위 결과 화면
     @Transactional(readOnly = true)
     public ChallengeResponse.CrewChallengeContributionRes getCrewChallengeContribution(String accessToken) {
         // 유저 조회
@@ -712,6 +714,58 @@ public class ChallengeService {
         );
     }
 
+    // 러닝 후 크루 챌린지 결과 확인
+    @Transactional(readOnly = true)
+    public ChallengeResponse.CrewChallengeRunningResult getCrewChallengeRunningResult (String accessToken) {
+
+        // 유저 조회
+        User user = jwtTokenProvider.getUserByToken(accessToken);
+
+        // 1. 유저의 현재 크루 챌린지 조회
+        UserCrewChallenge userCrewChallenge = userCrewChallengeRepository.findByUserId(user.getId());
+        CrewChallenge myCrewChallenge = userCrewChallenge.getCrewChallenge();
+
+        // 2. 유저가 속한 크루의 거리
+        List<ChallengeResponse.CrewMemberInfo> myCrewMembers = getCrewMemberInfo(user.getId(), myCrewChallenge.getId());
+
+        // 유저가 방금 뛴 거리
+        Optional<RunningData> latestRunning = runningDataRepository.findTopByUserIdAndStatusOrderByCreatedAtDesc(user.getId(), RunningDataStatus.ACTIVE);
+        double userDistance = latestRunning.get().getTotalDistance() / 1000.0;
+        double afterDistance = myCrewMembers.stream()
+                .mapToDouble(ChallengeResponse.CrewMemberInfo::runningDistance)
+                .sum();
+        double beforeDistance = afterDistance - userDistance;
+
+        // 3. 매칭된 크루 정보 조회
+        CrewChallenge matchedCrewChallenge = crewChallengeRepository.findById(myCrewChallenge.getMatchedCrewChallengeId())
+                .orElseThrow(() -> new ChallengeException(ErrorCode.CHALLENGE_NOT_FOUND));
+
+        String matchedCrewName = matchedCrewChallenge.getCrewName();
+        Tendency matchedCrewCreator = userCrewChallengeRepository.findByCrewChallengeIdAndIsCreator(matchedCrewChallenge.getId(), true)
+                .get().getUser().getTendency();
+
+        // 상태 검증 (두 크루 챌린지가 모두 종료가 안 됐을 경우)
+        if (myCrewChallenge.getChallengeStatus() != ChallengeStatus.COMPLETED
+                || matchedCrewChallenge.getChallengeStatus() != ChallengeStatus.COMPLETED) {
+            throw new ChallengeException(ErrorCode.CREW_CHALLENGE_COMPLETED);
+        }
+
+        // 4. 유저 크루와 매칭된 크루의 거리
+        List<Long> matchedCrewMemberIds = userCrewChallengeRepository
+                .findByCrewChallengeIdOrderByCreatedAt(matchedCrewChallenge.getId())
+                .stream()
+                .map(uc -> uc.getUser().getId())
+                .toList();
+
+        double matchedCrewDistance = matchedCrewMemberIds.stream()
+                .mapToDouble(memberId -> calculateTotalDistance(myCrewChallenge.getMatchedCrewChallengeId(), memberId))
+                .sum();
+
+        return new ChallengeResponse.CrewChallengeRunningResult(myCrewChallenge.getChallengePeriod().getDays(),
+                myCrewChallenge.getCrewName(), beforeDistance, userDistance, afterDistance, matchedCrewName,
+                matchedCrewCreator, matchedCrewDistance);
+    }
+
     // 활용 메소드들
     // 기간 검사
     private ChallengePeriod validateDates(LocalDate endDate) {
@@ -737,7 +791,7 @@ public class ChallengeService {
         return (int) ChronoUnit.DAYS.between(startDate, LocalDate.now()) + 1;
     }
 
-    // 달린 거리 계산
+    // 크루 챌린지 중 특정 유저의 달린 거리 계산
     private double calculateTotalDistance(Long challengeId, Long userId) {
         CrewChallenge challenge = crewChallengeRepository.findById(challengeId)
                 .orElseThrow(() -> new ChallengeException(ErrorCode.CHALLENGE_NOT_FOUND));
@@ -765,8 +819,8 @@ public class ChallengeService {
                 .collect(Collectors.toList());
     }
 
-    // 유저가 맨 앞으로, 이후로는 참여한 순서대로 (크루 챌린지 상세 진행도 및 결과 화면)
-    private List<ChallengeResponse.CrewMemberInfo> sortCrewMembersWithUser(Long userId, Long challengeId) {
+    // 참여자 정보 및 거리 조회
+    private List<ChallengeResponse.CrewMemberInfo> getCrewMemberInfo (Long userId, Long challengeId) {
         return userCrewChallengeRepository
                 .findByCrewChallengeIdOrderByCreatedAt(challengeId)
                 .stream()
@@ -775,11 +829,6 @@ public class ChallengeService {
                         calculateTotalDistance(challengeId, member.getUser().getId()),
                         member.getUser().getTendency()
                 ))
-                .sorted((m1, m2) -> {
-                    if (m1.userId().equals(userId)) return -1;
-                    if (m2.userId().equals(userId)) return 1;
-                    return 0;
-                })
                 .toList();
     }
 


### PR DESCRIPTION
## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #64  //

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 러닝 후 크루 챌린지 결과 조회 
- 크루 챌린지 COMPLETED 상태 변경 로직 수정 (둘 다 마감시간이 되어야 하도록)
- LocalDateTime & LocalDate 이슈 정리 

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] 작업한 API에 대해 적절한 **예외처리**가 이루어졌는가?
- [x] 작업한 API에 대해 적절한 **로그 메시지**가 작성되었는가? (`Controller`나 `Service`에서 `log.error` 활용)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

## ↗️ 개선 사항
<!-- 작업한 내용에 대해 좀 더 개선해야할 부분을 작성해주세요! -->

## 📔 참고 자료
- 선택 사항
![image](https://github.com/user-attachments/assets/932a5a58-d2fb-4fe2-850b-694686e55205)
